### PR TITLE
Update for 14.1

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-piwik-14.1 (1) turnkey; urgency=low
+
+  * Piwik:
+    - Latest upstream version of Piwik.
+    - Now using upstream .deb package.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Thu, 31 Dec 2015 11:03:24 +0100
+
 turnkey-piwik-14.0 (1) turnkey; urgency=low
 
   * Piwik:

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,9 +1,0 @@
-#!/bin/bash -ex
-
-dl() {
-    [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"
-    cd $2; curl -L -f -O $PROXY $1; cd -
-}
-
-dl http://builds.piwik.org/piwik.zip /usr/local/src
-

--- a/conf.d/main
+++ b/conf.d/main
@@ -9,13 +9,18 @@ ADMIN_PASS=turnkey
 ADMIN_MAIL=admin@example.com
 
 SRC=/usr/local/src
-WEBROOT=/var/www/piwik
+WEBROOT=/usr/share/piwik
 
-# unpack and set required permissions for inline upgrades
-unzip $SRC/piwik.zip -d $(dirname $WEBROOT)
-rm $SRC/piwik.zip
-rm $(dirname $WEBROOT)/How*
-chown -R www-data:www-data $WEBROOT
+cd $SRC
+wget https://debian.piwik.org/repository.gpg -qO piwik-repository.gpg
+sha256sum -c sha256 || exit 1
+
+cat piwik-repository.gpg | apt-key add -
+rm -f piwik-repository.gpg sha256
+cd -
+
+DEBIAN_FRONTEND=noninteractive apt-get update -y
+DEBIAN_FRONTEND=noninteractive apt-get install -y piwik
 
 # configure apache
 a2dissite 000-default
@@ -59,7 +64,7 @@ rm -f /tmp/cookie
 
 # configure mail and secure configuration file
 
-CONF=$WEBROOT/config/config.ini.php
+CONF=/etc/piwik/config.ini.php
 
 cat >> $CONF << EOF
 [mail]

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 DB_NAME=piwik
 DB_USER=piwik

--- a/conf.d/main
+++ b/conf.d/main
@@ -23,8 +23,8 @@ a2ensite piwik
 a2enmod rewrite
 
 # start services
-/etc/init.d/mysql start
-/etc/init.d/apache2 start
+service mysql start
+service apache2 start
 
 # setup the database
 MYSQL_BATCH="mysql --user=root --password=$MYSQL_PASS --batch"
@@ -73,6 +73,6 @@ chmod 640 $CONF
 sed -i 's|^\(memory_limit = \).*$|\1512M|' /etc/php5/apache2/php.ini
 
 # stop services
-/etc/init.d/mysql stop
-/etc/init.d/apache2 stop
+service mysql stop
+service apache2 stop
 

--- a/overlay/etc/apache2/sites-available/piwik.conf
+++ b/overlay/etc/apache2/sites-available/piwik.conf
@@ -3,18 +3,18 @@ ServerName localhost
 <VirtualHost *:80>
     UseCanonicalName Off
     ServerAdmin webmaster@localhost
-    DocumentRoot /var/www/piwik/
+    DocumentRoot /usr/share/piwik
 </VirtualHost>
 
 <VirtualHost *:443>
     SSLEngine on
     ServerAdmin webmaster@localhost
-    DocumentRoot /var/www/piwik/
+    DocumentRoot /usr/share/piwik
 </VirtualHost>
 
 <Directory /var/www/piwik/>
     Options +FollowSymLinks
     AllowOverride All
-Require all granted
+    Require all granted
 </Directory>
 

--- a/overlay/etc/apt/sources.list.d/piwik.list
+++ b/overlay/etc/apt/sources.list.d/piwik.list
@@ -1,0 +1,2 @@
+deb http://debian.piwik.org/ piwik main
+deb-src http://debian.piwik.org/ piwik main

--- a/overlay/usr/lib/inithooks/bin/piwik_config.py
+++ b/overlay/usr/lib/inithooks/bin/piwik_config.py
@@ -25,7 +25,7 @@ def usage(e=None):
     sys.exit(1)
 
 def update(section, name, value):
-    config_path = "/var/www/piwik/config/config.ini.php"
+    config_path = "/etc/piwik/config.ini.php"
     if not os.path.exists(config_path):
         raise Error("config file does not exist: %s" % config_path)
 

--- a/overlay/usr/local/src/sha256
+++ b/overlay/usr/local/src/sha256
@@ -1,0 +1,1 @@
+0d7c880f6c838bba2d02817dcacfc97fc538b1ebcdb41c3106595265c0d371d4  piwik-repository.gpg


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/485

Admittedly, the upstream .deb is not perfect — it assumes Apache 2.2 (https://github.com/piwik/piwik-package/issues/42). But it's not a big deal since it won't replace our supplied config.