### PR TITLE
ping upstream piwik package

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -11,6 +11,17 @@ ADMIN_MAIL=admin@example.com
 SRC=/usr/local/src
 WEBROOT=/usr/share/piwik
 
+# setup pinning
+REPO_ORIGIN="debian.piwik.org"
+cat >/etc/apt/preferences.d/piwik<<EOF
+Package: *
+Pin: origin "$REPO_ORIGIN"
+Pin-Priority: 100
+Package: piwik
+Pin: origin "$REPO_ORIGIN"
+Pin-Priority: 500
+EOF
+
 cd $SRC
 wget https://debian.piwik.org/repository.gpg -qO piwik-repository.gpg
 sha256sum -c sha256 || exit 1


### PR DESCRIPTION
Note to self & @qrntz & @ongle & anybody/everybody else:

Whenever we install from a non-debian/turnkey repo we need to pin the package(s). This way we will only ever install the packages that we explicitly wish to install. It eliminates the risk that Debian (or TurnKey) packages may be inadvertently installed from a 3rd party repo instead of where they should be being installed from.

I should have picked this up straight away when I merged the code. Luckily @alonswartz is on the job and spotted it.